### PR TITLE
Added missing samples for cpp

### DIFF
--- a/cpp/src/detectors/do-not-disable-html-autoescape/compliant.cpp
+++ b/cpp/src/detectors/do-not-disable-html-autoescape/compliant.cpp
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=do-not-disable-html-autoescape@v1.0 defects=0}
+#include <iostream>
+
+void compliant1() {
+	   char* query = getenv("QUERY_STRING");
+	   puts("<p>Query results for ");
+	   // Compliant: Escape HTML characters before adding to a page
+	   char* query_escaped = escape_html(query);
+	   puts(query_escaped);
+	   free(query_escaped);
+	 
+	   puts("\n<p>\n");
+	   puts(do_search(query));
+	 }
+// {/fact}

--- a/cpp/src/detectors/do-not-disable-html-autoescape/non-compliant.cpp
+++ b/cpp/src/detectors/do-not-disable-html-autoescape/non-compliant.cpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=do-not-disable-html-autoescape@v1.0 defects=1}
+#include <iostream>
+
+void noncompliant1() {
+	   char* query = getenv("QUERY_STRING");
+	   puts("<p>Query results for ");
+	   // Noncompliant: Printing out an HTTP parameter with no escaping
+	   puts(query);
+	   puts("\n<p>\n");
+	   puts(do_search(query));
+	 }
+// {/fact}

--- a/cpp/src/detectors/improper-restriction-on-memory-buffer/compliant.cpp
+++ b/cpp/src/detectors/improper-restriction-on-memory-buffer/compliant.cpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=improper-restriction-on-memory-buffer@v1.0 defects=0}
+#include <iostream>
+
+ void compliantTest1() {
+	     char buffer[20];
+	     const char* data = "ThisIsALongString";
+	     // Compliant: `strncpy` used to prevent buffer overflow
+	     strncpy(buffer, data, sizeof(buffer) - 1);
+	     buffer[sizeof(buffer) - 1] = '\0';  // Null-terminate the string
+	 }
+	    
+// {/fact}

--- a/cpp/src/detectors/improper-restriction-on-memory-buffer/non-compliant.cpp
+++ b/cpp/src/detectors/improper-restriction-on-memory-buffer/non-compliant.cpp
@@ -1,0 +1,16 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=improper-restriction-on-memory-buffer@v1.0 defects=1}
+#include <iostream>
+
+ void nonCompliantTest1() {
+	     char buffer[10];
+	     const char* data = "ThisIsALongString";
+	     // Non-compliant: Buffer overflow may occur no size check
+	     strcpy(buffer, data);
+	 }
+	    
+// {/fact}

--- a/cpp/src/detectors/insecure-cryptography/compliant.cpp
+++ b/cpp/src/detectors/insecure-cryptography/compliant.cpp
@@ -1,0 +1,16 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=insecure-cryptography@v1.0 defects=0}
+#include <iostream>
+
+ void compliant1(EVP_PKEY_CTX *ctx)
+	 {
+	     
+	     // compliaint: 2048 bits for an RSA key
+	     EVP_PKEY_CTX_set_rsa_keygen_bits(ctx, 2048);
+	    
+	 }
+// {/fact}

--- a/cpp/src/detectors/insecure-cryptography/non-compliant.cpp
+++ b/cpp/src/detectors/insecure-cryptography/non-compliant.cpp
@@ -1,0 +1,16 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=insecure-cryptography@v1.0 defects=1}
+#include <iostream>
+
+ void noncompliant1(EVP_PKEY_CTX *ctx)
+	 {
+	 
+	     // Noncompiat: only 1024 bits for an RSA key
+	     EVP_PKEY_CTX_set_rsa_keygen_bits(ctx, 1024);  
+	 }
+	    
+// {/fact}


### PR DESCRIPTION
Added missing samples for cpp for rules:
`cpp/do-not-disable-html-autoescape@v1.0`
`cpp/insecure-cryptography@v1.0`
`cpp/improper-restriction-on-memory-buffer@v1.0`

