### PR TITLE
Fixed typo for c detector library samples

### DIFF
--- a/c/src/detectors/unhandled-expression-result/compliant.c
+++ b/c/src/detectors/unhandled-expression-result/compliant.c
@@ -8,7 +8,7 @@
 
 int unhandledExpressionResultCompliant(int a, int b) {
     int result = 0;
-    // Compliant: Expression result is handled by veriable
+    // Compliant: Expression result is handled by variable
     result = a + b; 
     return result;
 }

--- a/c/src/detectors/unhandled-expression-result/non-compliant.c
+++ b/c/src/detectors/unhandled-expression-result/non-compliant.c
@@ -8,7 +8,7 @@
 
 int unhandledExpressionResultNonCompliant(int a, int b) {
     int result = 0;
-    // Noncompliant: Unnecessary operation, expression result is not handled by any veriable here
+    // Noncompliant: Unnecessary operation, expression result is not handled by any variable here
     a + b; 
     return result;
 }


### PR DESCRIPTION

*Description of changes:*


Fixed typo for c detector library samples: 
`the comments say 'veriable' instead of 'variable'.`
