### PR TITLE
Add correct sample for 'insecure-connection'.

### DIFF
--- a/javascript/src/detectors/insecure_connection/insecure_connection.js
+++ b/javascript/src/detectors/insecure_connection/insecure_connection.js
@@ -5,26 +5,34 @@
 
 
 // {fact rule=insecure-connection@v1.0 defects=1}
-var net = require('net')
-var socket = new net.Socket()
-function insecureConnectionNoncompliant()
-{
-    var port = 0
-    // Noncompliant: host value is not specified.
-    var host = ''
-    var server = socket.connect(port, host)
-}
+const nodemailerClient = require("nodemailer");
+
+let transporter = nodemailerClient.createTransport({
+    service: "gmail",
+    auth: {
+        user: "youremail@gmail.com",
+        pass: "yourpassword"
+    },
+    // Noncompliant: `requireTLS` is set to `false` which is insecure as it disables Transport Layer Security(TLS).
+    requireTLS: false
+});
+
+console.log('Transporter created:', transporter);
 // {/fact}
 
 
 // {fact rule=insecure_connection@v1.0 defects=0}
-var net = require('net')
-var socket = new net.Socket()
-function insecureConnectionCompliant()
-{
-    var port = 0
-    // Compliant: host value is specified.
-    var host = '192.168.1.1'
-    var server = socket.connect(port, host)
-}
+const nodemailerClient = require("nodemailer");
+
+let transporter = nodemailerClient.createTransport({
+    service: "gmail",
+    auth: {
+        user: "youremail@gmail.com",
+        pass: "yourpassword"
+    },
+    // Compliant: `requireTLS` is set to `true` which is secure as it enables Transport Layer Security(TLS).
+    requireTLS: true
+});
+
+console.log('Transporter created:', transporter);
 // {/fact}


### PR DESCRIPTION
Removed the incorrect sample for the 'JavaScript - insecure connection' case and replaced it with an appropriate example.